### PR TITLE
When `Pkg.add`ing CoverageTools, use the name, UUID, and version

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -18,8 +18,7 @@ fi
 julia -e 'using Pkg
           Pkg.UPDATED_REGISTRY_THIS_SESSION[] = true
           Pkg.activate("julia-coverage", shared=true)
-          Pkg.add(PackageSpec(name="CoverageTools"))
-
+          Pkg.add(PackageSpec(name="CoverageTools", uuid="c36e975a-824b-4404-a568-ef97ca766997", version="1"))
           using CoverageTools
           pf = vcat(map(process_folder, ARGS)...)
           LCOV.writefile("lcov.info", pf)' "${dirs[@]}"


### PR DESCRIPTION
1. In the future, we may allow multiple packages in the General registry that have the same name. If that ever happens, we need to make sure that in scripts we add packages with both name and UUID.
2. In the future, there may be a 2.0 release of CoverageTools that has breaking changes. Therefore, we should specify the major version number of CoverageTools that we want to install.