### PR TITLE
Don't hard-code path to bash.

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 


### PR DESCRIPTION
Some of the features used here aren't compatible with macOS' system bash (v3.something), so we want to be able to use a more recent version.