### PR TITLE
Add support for flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ plugin.
 ## Options
 
 * `dirs`: A list of directories to process coverage for. Defaults to `src`.
+* `flags`: A list of flags to categorize the coverage reports. These flags can be used to generate separate coverage badges for different aspects of your project, which is particularly useful for monorepos. Defaults to an empty list.

--- a/plugin.yml
+++ b/plugin.yml
@@ -6,6 +6,8 @@ configuration:
   properties:
     dirs:
       type: array
+    flags:
+      type: array
     fail-on-error:
       type: boolean
   additionalProperties: false

--- a/src/main.jl
+++ b/src/main.jl
@@ -99,6 +99,15 @@ function coverage_dirs()
     return dirs
 end
 
+function coverage_flags()
+    flags = String[]
+    for (k, v) in ENV
+        if occursin(r"^BUILDKITE_PLUGIN_JULIA_COVERAGE_FLAGS_[0-9]+$", k)
+            push!(flags, v)
+        end
+    end
+    return flags
+end
 
 # Process the coverage files
 function process_coverage(dirs)
@@ -136,6 +145,9 @@ function upload_coverage(exepath)
         --disable-search
         --file lcov.info
     ```
+    for flag in coverage_flags()
+        cmd = `$cmd --flag $flag`
+    end
     if (token = get(ENV, "CODECOV_TOKEN", nothing); token !== nothing)
         cmd = `$cmd --token $token`
     end


### PR DESCRIPTION
Hi! I added support for flags. They can be passed as an array in a new `flags` field, for example:

```yml
plugins:
    - JuliaCI/julia-coverage:
        codecov: true
        flags:
          - core
        dirs:
          - KomaMRICore/src
          - KomaMRICore/ext
```

This is particularly useful to generate badges for different packages inside a mono-repo. I tested it [here](https://github.com/JuliaHealth/KomaMRI.jl/pull/588/files) and it seems to be working properly, but I am not really sure how to add tests for pipelines.